### PR TITLE
[Generator] preliminary data class generation and @generic annotation

### DIFF
--- a/example/lib/sealed_test.dart
+++ b/example/lib/sealed_test.dart
@@ -2,10 +2,26 @@ import 'package:sealed_ugh/sealed_ugh.dart';
 
 part "sealed_test.g.dart";
 
-@sealed
+@sealed @generic
 enum _SealedTest {
+  
   @object
   FirstObj,
-  @Data()
+
+  @Data(fields: [DataField('f1', double), DataField('f2', int)])
   SecondObj,
+
+  @Data(fields: [DataField('f1', int), DataField('f2', Generic)])
+  @generic
+  ThirdObj,
+
+  @object
+  FourthObj,
+}
+
+class MyClass {
+  final String a;
+  final int b;
+
+  const MyClass(this.a, this.b);
 }

--- a/example/lib/sealed_test.g.dart
+++ b/example/lib/sealed_test.g.dart
@@ -6,30 +6,57 @@ part of 'sealed_test.dart';
 // SealedUghGenerator
 // **************************************************************************
 
+@immutable
 abstract class SealedTest<T> {
-  SealedTest(this._type);
+  const SealedTest(this._type);
 
   final _SealedTest _type;
 
 //ignore: missing_return
   R when<R>(
       {@required R Function(FirstObj) onFirstObj,
-      @required R Function(SecondObj) onSecondObj}) {
+      @required R Function(SecondObj) onSecondObj,
+      @required R Function(ThirdObj) onThirdObj,
+      @required R Function(FourthObj) onFourthObj}) {
     switch (this._type) {
       case _SealedTest.FirstObj:
         return onFirstObj(this as FirstObj);
       case _SealedTest.SecondObj:
         return onSecondObj(this as SecondObj);
+      case _SealedTest.ThirdObj:
+        return onThirdObj(this as ThirdObj);
+      case _SealedTest.FourthObj:
+        return onFourthObj(this as FourthObj);
     }
   }
 }
 
-class FirstObj<T> extends SealedTest {
-  FirstObj() : super(_SealedTest.FirstObj);
+@immutable
+class FirstObj extends SealedTest {
+  const FirstObj() : super(_SealedTest.FirstObj);
 }
 
-class SecondObj<T> extends SealedTest {
-  SecondObj(this.value) : super(_SealedTest.SecondObj);
+@immutable
+class SecondObj extends SealedTest {
+  const SecondObj({@required this.f1, @required this.f2})
+      : super(_SealedTest.SecondObj);
 
-  final T value;
+  final double f1;
+
+  final int f2;
+}
+
+@immutable
+class ThirdObj<T> extends SealedTest {
+  const ThirdObj({@required this.f1, @required this.f2})
+      : super(_SealedTest.ThirdObj);
+
+  final int f1;
+
+  final T f2;
+}
+
+@immutable
+class FourthObj extends SealedTest {
+  const FourthObj() : super(_SealedTest.FourthObj);
 }

--- a/sealed_ugh/lib/src/annotations.dart
+++ b/sealed_ugh/lib/src/annotations.dart
@@ -14,8 +14,22 @@ class Object {
   const Object();
 }
 
-
 @immutable
 class Data {
-  const Data();
+  final List<DataField> fields;
+  const Data({@required this.fields});
+}
+
+const generic = Generic();
+
+@immutable
+class Generic {
+  const Generic();
+}
+
+@immutable
+class DataField {
+  final String name;
+  final Type type;
+  const DataField(this.name, this.type);
 }


### PR DESCRIPTION
- Can specify the enum annotated with `@sealed` as `@generic.`
- Can specify field annotated with `@Data()` as `@generic`
- Cannot specify field annotated with `@Object()` as `@generic`
- Can add a list of `DataFields `to fields parameter of `@Data()`
- Iff a field annotated with `@Data()` also has `@generic`, it must have at least one `Generic DataField` (check `example/lib/sealed_test.dart`)
- Iff a field annotated with `@Data()` also has `@generic`, its parent enum must be annotated with `@generic`